### PR TITLE
fix inconsistent PDOException code type

### DIFF
--- a/src/Actions/Processors/AbstractBaseProcessor.php
+++ b/src/Actions/Processors/AbstractBaseProcessor.php
@@ -238,7 +238,7 @@ abstract class AbstractBaseProcessor extends AbstractProcessor
             $message = sprintf('%s when executing SQL "%s"', $pdoe->getMessage(), preg_replace('/\r\n\s\s+/', ' ', $sql));
 
             // re-throw the exception with a more detailed error message
-            throw new \PDOException($message, $pdoe->getCode());
+            throw new \PDOException($message);
         }
     }
 


### PR DESCRIPTION
- PDOException::getCode() may return a string. That is inconsistent to definition of Exception and will cause an error, when a new exception is created with the value of getCode() as second constructor argument. Therefore passthrough of exception code is removed